### PR TITLE
Fix crash with 'string' being undefined.

### DIFF
--- a/dist/contact-parser.js
+++ b/dist/contact-parser.js
@@ -338,7 +338,7 @@ ContactParser = (function() {
         if (indexes['address'] === indexes['province'] - 1) {
           parts = result.address.split(' ');
           possibleCity = parts.pop();
-          result.address = string.join(' ', parts);
+          result.address = parts.join(' ');
         }
       }
       result.city = possibleCity;

--- a/spec/contact-parser-spec.coffee
+++ b/spec/contact-parser-spec.coffee
@@ -214,3 +214,11 @@ describe 'Contact Parser', ->
     expect(result.postal).toEqual('M5E 1W7')
     expect(result.country).toEqual('Canada')
 
+  it 'If we have trouble finding the city name, try the last word from the address. This might be wrong.', ->
+    address = "1 17th Street #5, CO 12345-1234"
+    sut = new ContactParser
+    result = sut.parse(address)
+    expect(result.address).toEqual('1 17th Street') # Note we're wrong on this case. #5 is missing
+    expect(result.city).toEqual('#5') # Not we caused wrong here. Should be empty.
+    expect(result.province).toEqual('CO')
+    expect(result.postal).toEqual('12345-1234')

--- a/src/contact-parser.coffee
+++ b/src/contact-parser.coffee
@@ -229,7 +229,7 @@ class ContactParser
           # Hope it's a one word city name, because there's no good way to parse it out
           parts = result.address.split(' ')
           possibleCity = parts.pop()
-          result.address = string.join(' ', parts)
+          result.address = parts.join(' ')
       result.city = possibleCity
       usedFields.push(indexes['province']-1)
 


### PR DESCRIPTION
This fix implements how it appears the code was intended to work, but not that
while the parsing doesn't fail in this case, it does wrongly guess the city
name.

I would rather have no answer than a wrong answer, so I would be OK with no
city name being returned.

If you want to more aggressively try to find a city name, could try some other strategies:
- Make sure prospective city name doesn't match the "Apt #" regex, like "#5" here.
- Make sure the city name doesn't look like a street designator, like "Street"

Even then, you still fail on all two word city names, so I think it would be
nice to at least have an /option/ here to just give up on trying to find the
city name, if not give up completely in this case.
