### PR TITLE
This is the fix I prefer for dealing with both the undefined string error and ambiguity about parsing city names.

### DIFF
--- a/dist/contact-parser.js
+++ b/dist/contact-parser.js
@@ -223,7 +223,7 @@ ContactParser = (function() {
   };
 
   ContactParser.prototype.parse = function(address) {
-    var addressRegex, canadianPostalRegex, emailRegex, extraInfo, field, fields, i, indexes, ix, key, matches, parts, phoneRegex, poBoxRegex, possibleCity, replacement, result, ri, search, secondCheck, streetNameRegex, subfield, subfields, trim, usZipRegex, usedFields, value, websiteRegex, _i, _j, _len, _len1, _ref, _ref1, _ref2, _ref3, _ref4;
+    var addressRegex, canadianPostalRegex, emailRegex, extraInfo, field, fields, i, indexes, ix, key, matches, phoneRegex, poBoxRegex, possibleCity, replacement, result, ri, search, secondCheck, streetNameRegex, subfield, subfields, trim, usZipRegex, usedFields, value, websiteRegex, _i, _j, _len, _len1, _ref, _ref1, _ref2, _ref3, _ref4;
     result = new ContactParserResult;
     indexes = {};
     usedFields = [];
@@ -336,9 +336,7 @@ ContactParser = (function() {
       possibleCity = trim(fields[indexes['province'] - 1]);
       if (_ref3 = indexes['province'] - 1, __indexOf.call(usedFields, _ref3) >= 0) {
         if (indexes['address'] === indexes['province'] - 1) {
-          parts = result.address.split(' ');
-          possibleCity = parts.pop();
-          result.address = parts.join(' ');
+          possibleCity = '';
         }
       }
       result.city = possibleCity;

--- a/spec/contact-parser-spec.coffee
+++ b/spec/contact-parser-spec.coffee
@@ -214,11 +214,11 @@ describe 'Contact Parser', ->
     expect(result.postal).toEqual('M5E 1W7')
     expect(result.country).toEqual('Canada')
 
-  it 'If we have trouble finding the city name, try the last word from the address. This might be wrong.', ->
+  it 'should give up finding the city name rather than returning a possible wrong result', ->
     address = "1 17th Street #5, CO 12345-1234"
     sut = new ContactParser
     result = sut.parse(address)
-    expect(result.address).toEqual('1 17th Street') # Note we're wrong on this case. #5 is missing
-    expect(result.city).toEqual('#5') # Not we caused wrong here. Should be empty.
+    expect(result.city).toEqual('')
+    expect(result.address).toEqual('1 17th Street #5')
     expect(result.province).toEqual('CO')
     expect(result.postal).toEqual('12345-1234')

--- a/src/contact-parser.coffee
+++ b/src/contact-parser.coffee
@@ -226,10 +226,8 @@ class ContactParser
       if (indexes['province']-1) in usedFields
         # We've used this for something else
         if indexes['address'] == indexes['province']-1
-          # Hope it's a one word city name, because there's no good way to parse it out
-          parts = result.address.split(' ')
-          possibleCity = parts.pop()
-          result.address = parts.join(' ')
+          # We've already used the field before the province for the address, so give up on city parsing.
+          possibleCity = '';
       result.city = possibleCity
       usedFields.push(indexes['province']-1)
 


### PR DESCRIPTION
Now if the city name hasn't been found and and address _has_ been found, we
give up on finding the city name rather than assuming the city name is the last single word
in the address string. 

If the city name is more than one word or the city name is simply missing, then
both the address and the city name will end up wrong.

Better to just leave the city name empty in that case.
