### PR TITLE
Fixes #16: "npm test" now runs the tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   },
   "author": "Jason Doucette",
   "license": "MIT",
+  "scripts" : {
+    "test" : "grunt jasmine_node -v"
+  },
   "devDependencies": {
     "jasmine-node": "~1.14.5",
     "coffee-script": "~1.7.0",


### PR DESCRIPTION
Verbose output is enabled, since we presume if someone is running the
  tests, they are likely interested in *what* they are testing as well
  the final result.