### PR TITLE
After reviewing the README, I noticed the module could be easier to find.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+
+### v0.0.7
+
+No code changes.
+
+    * Cleaned up README and fixed a typo in the test. 
+
 ### v0.0.6
 
     * Improved support parsing dozens more street names (#15, Thanks to Mark Stosberg)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # contact-parser
 
-A simple node module to parse address information (such as an email signature)
+A simple node module to parse street address strings (such as an email signature)
 into component parts.  It's in use over at [Barnivore](http://barnivore.com/)
-where we input a lot of addresses.
+where we input a lot of street addresses.
 
-At present it's optimized for North America; other address formats will be
+At present it's optimized for United States and Canadian street addresses; other address formats will be
 supported as we hammer the bugs out in production.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ I'm sure there are several :) Help fix them by submitting an issue, or better ye
 
 ## License
 
-** MIT **
+[MIT](./MIT.LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contact-parser",
-  "version": "0.0.6",
-  "description": "Parse a block of text (such as an email signature) and extract address fields",
+  "version": "0.0.7",
+  "description": "Parse a block of text (such as an email signature) and extract US and CA street address fields",
   "main": "dist/contact-parser.js",
   "homepage" : "https://github.com/thrustlabs/contact-parser",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.6",
   "description": "Parse a block of text (such as an email signature) and extract address fields",
   "main": "dist/contact-parser.js",
+  "homepage" : "https://github.com/thrustlabs/contact-parser",
   "repository": {
     "type": "git",
     "url": "https://github.com/thrustlabs/contact-parser.git"

--- a/spec/contact-parser-spec.coffee
+++ b/spec/contact-parser-spec.coffee
@@ -254,7 +254,7 @@ describe 'Contact Parser', ->
     expect(result.province).toEqual('CO')
     expect(result.postal).toEqual('12345-1234')
 
-  it 'should parse when common between address and city is missing and street name is avenue', ->
+  it 'should parse when comma between address and city is missing and street name is avenue', ->
     address = "12345 East Center Avenue Aurora, CO 80012"
     sut = new ContactParser
     result = sut.parse(address)


### PR DESCRIPTION
In particular, it could mention *street* address parsing, and explicitly mention
United States and Canadian, as people would be more likely to search for specific
country names than North American. 

Other misc cleanups as well detailed in the commits.

History.md and package.json have also been updated, so this is ready for release.